### PR TITLE
SDEMO-124: Content block

### DIFF
--- a/_config/startup.yml
+++ b/_config/startup.yml
@@ -2,6 +2,14 @@
 Name: startup-theme-components
 ---
 
+DNADesign\Elemental\Models\BaseElement:
+  extensions:
+  - SilverStripe\StartupTheme\BaseElementExtension
+
+DNADesign\Elemental\Models\ElementContent:
+  extensions:
+    - SilverStripe\StartupTheme\ElementContentExtension
+
 Heyday\MenuManager\MenuSet:
   default_sets:
     - MainMenu

--- a/src/Extensions/BaseElementExtension.php
+++ b/src/Extensions/BaseElementExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\StartupTheme;
+
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataExtension;
+
+class BaseElementExtension extends DataExtension
+{
+    private static array $db = [
+        'BlockBackgroundColor' => 'Varchar(255)',
+    ];
+
+    private static $blockBackgroundColors = [
+        'white' => 'White',
+        'pale-grey' => 'Grey',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function updateCMSFields(FieldList $fields): void
+    {
+        $fields->addFieldsToTab(
+            'Root.Settings',
+            [
+                DropdownField::create(
+                    'BlockBackgroundColor',
+                    'Background color',
+                    static::$blockBackgroundColors
+                )
+            ]
+        );
+    }
+
+    public function getBlockName(): string
+    {
+        return strtolower(str_replace(' ', '-', strtolower($this->owner->singular_name())));
+    }
+
+    public function getSectionColorClass(): string
+    {
+        return sprintf('section--color-%s',  $this->owner->BlockBackgroundColor ?? 'white');
+    }
+
+}

--- a/src/Extensions/DefaultRecordsExtension.php
+++ b/src/Extensions/DefaultRecordsExtension.php
@@ -2,12 +2,16 @@
 
 namespace SilverStripe\StartupTheme;
 
+use DNADesign\Elemental\Models\ElementContent;
 use Heyday\MenuManager\MenuItem;
 use Heyday\MenuManager\MenuSet;
 use Page;
+use SilverStripe\CMS\Controllers\RootURLController;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\SiteConfig\SiteConfig;
+use SilverStripe\StartupThemeComponents\PageTypes\BlocksPage;
 
 class DefaultRecordsExtension extends DataExtension
 {
@@ -24,9 +28,11 @@ class DefaultRecordsExtension extends DataExtension
         // So provided SiteConfig doesn't exist, we know this is the first dev/build on a fresh DB,
         // and we want to create default pages, menus and blocks.
         if (!SiteConfig::get()->first()) {
+            // Create Home page
+            $this->createHomePage();
+
             // Create pages (adding pages here interferes with the core SiteTree logic which will create the About and
-            // Contact pages based on the current page count, so we'll add our own ones here. Home page still gets made
-            // within the SiteTree requireDefaultRecords() hook).
+            // Contact pages based on the current page count, so we'll add our own ones here.
             $pages = [
                 'About',
                 'Resources',
@@ -77,5 +83,60 @@ class DefaultRecordsExtension extends DataExtension
                 $footerMenu->MenuItems()->add($item);
             }
         }
+    }
+
+    /**
+     * Create Home page
+     *
+     * The Home page normally gets created within the SiteTree requireDefaultRecords() hook which
+     * runs after this extension. As we require the Home page to be of `BlocksPage` page type,
+     * it must be created here.
+     *
+     * @return void
+     * @throws ValidationException
+     */
+    public function createHomePage(): void
+    {
+        $page = BlocksPage::create([
+            'Title' => 'Home',
+            'URLSegment' => RootURLController::config()->get('default_homepage_link'),
+            'ShowHero' => '0',
+            'Sort' => '1',
+        ]);
+        $page->write();
+        $page->publishSingle();
+        DB::alteration_message('Home page created', 'created');
+
+        // Create content block
+        $page = Page::get()->filter('Title', 'Home')->first();
+        $block = ElementContent::create([
+            'TopPageID' => $page->ID,
+            'ParentID' => $page->ElementalAreaID,
+            'Title' => 'Block heading 2',
+            'ShowTitle' => '1',
+            'BlockBackgroundColor' => 'pale-grey',
+            'BlockNarrowContentWidth' => '1',
+            'HTML' => '
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eu quam orci. Duis vitae rutrum
+                metus. Vivamus eu erat vulputate, ornare sem et, auctor diam. Ut nec mollis neque, vehicula mollis
+                dolor. Proin vel quam cursus, malesuada sapien vel, maximus urna. Sed lectus ligula, lacinia non mauris
+                at, maximus placerat sapien. Proin euismod augue et felis hendrerit commodo. Proin gravida urna a velit
+                molestie fringilla. Maecenas consectetur dui vitae tellus scelerisque, non posuere massa tincidunt.
+                Etiam porta sed mi eget hendrerit.</p>
+                <p>Nunc sed massa in erat venenatis rutrum. Sed nec pretium neque. Etiam laoreet id ex vitae porttitor.
+                Quisque quis lacus lacinia nisi laoreet sodales sit amet rutrum eros. Duis pulvinar porttitor quam vel
+                pellentesque. Nulla facilisi. Pellentesque habitant morbi tristique senectus et netus et malesuada
+                fames ac turpis egestas. Quisque et dui sed sem suscipit varius quis sit amet massa. Nullam lacinia est
+                non lorem luctus accumsan.</p>
+                <h3>Heading 3</h3>
+                <p>Ut nec felis congue, tincidunt sapien et, lacinia neque. In ac est a risus luctus porta. Donec eget
+                tincidunt mi. Vestibulum efficitur nisi eu enim tincidunt, luctus finibus turpis dignissim. Nulla
+                sollicitudin viverra neque eu aliquam. Nunc in feugiat risus, et sodales libero. Morbi eleifend magna
+                sit amet quam tempor aliquet. Praesent eget odio laoreet, efficitur nulla sed, gravida urna. Morbi
+                elementum suscipit urna, a aliquam est congue auctor.</p>
+                ',
+        ]);
+        $block->write();
+        $page->publishRecursive();
     }
 }

--- a/src/Extensions/ElementContentExtension.php
+++ b/src/Extensions/ElementContentExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\StartupTheme;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataExtension;
+
+class ElementContentExtension extends DataExtension
+{
+    private static array $db = [
+        'BlockNarrowContentWidth' => 'Varchar(255)',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function updateCMSFields(FieldList $fields): void
+    {
+        $fields->addFieldsToTab(
+            'Root.Settings',
+            [
+                CheckboxField::create(
+                    'BlockNarrowContentWidth',
+                    'Narrow content width?'
+                ),
+            ]
+        );
+    }
+
+}

--- a/src/PageTypes/BlocksPage.php
+++ b/src/PageTypes/BlocksPage.php
@@ -10,6 +10,8 @@ class BlocksPage extends Page
 
     private static string $table_name = 'BlocksPage';
 
+    private static $icon_class = 'font-icon-p-alt-2';
+
     private static array $db = [
         'ShowHero' => 'Boolean',
     ];
@@ -25,7 +27,7 @@ class BlocksPage extends Page
         $fields->insertAfter(
             'MenuTitle',
             CheckboxField::create(
-                'ShowHero', 
+                'ShowHero',
                 'Show Hero',
             )->setDescription('Show hero area containing breadcrumbs and page name.'),
         );

--- a/themes/startup-theme-components/templates/DNADesign/Elemental/Layout/ElementHolder.ss
+++ b/themes/startup-theme-components/templates/DNADesign/Elemental/Layout/ElementHolder.ss
@@ -1,0 +1,3 @@
+<section class="section {$SectionColorClass}" id="$Anchor">
+    $Element
+</section>

--- a/themes/startup-theme-components/templates/DNADesign/Elemental/Models/ElementContent.ss
+++ b/themes/startup-theme-components/templates/DNADesign/Elemental/Models/ElementContent.ss
@@ -1,0 +1,6 @@
+<div class="block {$BlockName} container<% if $BlockNarrowContentWidth %> container--narrow<% end_if %>">
+    <% if $ShowTitle %><h2 class="block__h2">$Title</h2><% end_if %>
+    <div class="typography">
+        $HTML
+    </div>
+</div>

--- a/themes/startup-theme-components/templates/Includes/Footer.ss
+++ b/themes/startup-theme-components/templates/Includes/Footer.ss
@@ -1,6 +1,6 @@
 <footer class="footer">
     <div class="container container--footer">
-        <nav class="nav nav--footer">
+        <nav aria-label="Footer">
             <ul class="footer-menu">
                 <li class="footer-menu__item footer-menu__item--copyright">
                     &copy; $CurrentDatetime.Format("y") $SiteConfig.Title

--- a/themes/startup-theme-components/templates/Includes/Header.ss
+++ b/themes/startup-theme-components/templates/Includes/Header.ss
@@ -1,38 +1,41 @@
 <header class="header">
     <div class="container container--header">
-        <div class="header-main">
-            <a href="$baseURL" class="logo">
-                <img src="$resourceURL('themes/startup/images/logo--white.svg')" alt="{$SiteConfig.Title}">
-            </a>
+        <a href="$baseURL" class="logo">
+            <img src="$resourceURL('themes/startup/images/logo--white.svg')" alt="{$SiteConfig.Title}">
+        </a>
 
-            <%-- Desktop menu --%>
-            <nav class="nav nav--desktop">
-                <ul class="menu">
-                    <% loop $MenuSet('MainMenu').MenuItems %>
-                        <li class="menu__item<% if $Children %> menu__item--has-submenu<% end_if %>">
-                            <a href="$Link" class="menu__link" <% if $IsNewWindow %>target="_blank" rel="noopener noreferrer"<% end_if %>>$MenuTitle</a>
-                            <% if $Children %>
-                                <ul class="submenu">
-                                    <% loop $Children %>
-                                        <li class="submenu__item">
-                                            <a href="$Link" class="submenu__link">$MenuTitle</a>
-                                        </li>
-                                    <% end_loop %>
-                                </ul>
-                            <% end_if %>
-                        </li>
-                    <% end_loop %>
-                </ul>
-            </nav>
-        </div>
-        <%-- SiteConfig Header Button Link  --%>
+        <%-- Desktop menu --%>
+        <nav class="nav nav--desktop" aria-label="Main">
+            <ul class="menu">
+                <% loop $MenuSet('MainMenu').MenuItems %>
+                    <li class="menu__item<% if $Children %> menu__item--has-submenu<% end_if %>">
+                        <a href="$Link" class="menu__link" <% if $IsNewWindow %>target="_blank" rel="noopener noreferrer"<% end_if %>>$MenuTitle</a>
+                        <% if $Children %>
+                            <ul class="submenu">
+                                <% loop $Children %>
+                                    <li class="submenu__item">
+                                        <a href="$Link" class="submenu__link">$MenuTitle</a>
+                                    </li>
+                                <% end_loop %>
+                            </ul>
+                        <% end_if %>
+                    </li>
+                <% end_loop %>
+            </ul>
+        </nav>
+
+        <%-- SiteConfig header button link --%>
         <% with $SiteConfig  %>
             <% if $HeaderButton %>
-                <div class="header-button">
-                    <button class="button">$HeaderButton</button>
-                </div>
+                <a class="header__button button button--header<% if $HeaderButton.OpenInNew %> button--external<% end_if %>"
+                   href="$HeaderButton.URL"
+                   <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
+                >
+                    $HeaderButton.Title
+                </a>
             <% end_if %>
         <% end_with %>
+
         <%-- Mobile menu controls --%>
         <button class="hamburger" type="button" aria-label="Toggle menu" data-toggle-mobile-menu>
             <span class="hamburger__lines"></span>
@@ -42,7 +45,7 @@
         <div class="modal__background" data-toggle-mobile-menu></div>
 
         <%-- Mobile menu --%>
-        <nav class="nav nav--mobile">
+        <nav class="nav nav--mobile" aria-label="Main">
             <a href="$BaseHref" class="logo logo--mobile">
                 <img class="logo__image" src="$resourceURL('themes/startup/images/logo--black.svg')" alt="{$SiteConfig.Title}">
             </a>
@@ -70,12 +73,15 @@
                     </li>
                 <% end_loop %>
             </ul>
-            <%-- SiteConfig Mobile nav Header Button Link  --%>
+            <%-- SiteConfig mobile nav header button link  --%>
             <% with $SiteConfig  %>
                 <% if $HeaderButton %>
-                    <div class="mobile-menu__button">
-                        <button type="button" class="button">$HeaderButton</button>
-                    </div>
+                    <a class="mobile-menu__button button<% if $HeaderButton.OpenInNew %> button--external<% end_if %>"
+                       href="$HeaderButton.URL"
+                       <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
+                    >
+                        $HeaderButton.Title
+                    </a>
                 <% end_if %>
             <% end_with %>
         </nav>

--- a/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/PageTypes/Layout/BlocksPage.ss
+++ b/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/PageTypes/Layout/BlocksPage.ss
@@ -1,16 +1,11 @@
-<% if $ShowHero %>
-    <div class="hero">
-        <div class="container">
-            $Breadcrumbs
-            <h1 class="page__title">$Title</h1>
+<main>
+    <% if $ShowHero %>
+        <div class="hero">
+            <div class="container">
+                $Breadcrumbs
+                <h1 class="page__title">$Title</h1>
+            </div>
         </div>
-    </div>
-<% end_if %>
-
-<main class="container container--page">
-    <div class="page">
-        <div class="page__content">
-            $ElementalArea
-        </div>
-    </div>
+    <% end_if %>
+    $ElementalArea
 </main>


### PR DESCRIPTION
## SDEMO-124: General content block

### Acceptance criteria

- Block with a WYSIWYG
- Optional block heading (title)
- Checkbox for narrow centred column (full width is default)
- Option to have a grey background (default is white)

### Summary of changes
- Refactor of CSS so that properties appear in alphabetical order
- Quick refactor of footer CSS
- Refactor of header button

Other PRs part of this card:
- https://github.com/silverstripeltd/startup-theme/pull/14
- https://github.com/silverstripeltd/demo-startup-staging/pull/5
