### PR TITLE
Feature/sdemo 706 startup component items

### DIFF
--- a/_config/startup.yml
+++ b/_config/startup.yml
@@ -19,6 +19,7 @@ SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - SilverStripe\StartupTheme\DefaultRecordsExtension
     - SilverStripe\StartupTheme\HeaderButtonExtension
+    - SilverStripe\StartupTheme\SiteConfigExtension
 
 SilverStripe\StartupThemeComponents\PageTypes\BlocksPage:
   extensions:
@@ -27,4 +28,3 @@ SilverStripe\StartupThemeComponents\PageTypes\BlocksPage:
 Page:
   extensions:
     - SilverStripe\StartupTheme\PageExtension
-

--- a/_config/startup.yml
+++ b/_config/startup.yml
@@ -24,3 +24,7 @@ SilverStripe\StartupThemeComponents\PageTypes\BlocksPage:
   extensions:
     - DNADesign\Elemental\Extensions\ElementalPageExtension
 
+Page:
+  extensions:
+    - SilverStripe\StartupTheme\PageExtension
+

--- a/src/Extensions/BaseElementExtension.php
+++ b/src/Extensions/BaseElementExtension.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\StartupTheme;
 
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
 
-class BaseElementExtension extends DataExtension
+class BaseElementExtension extends Extension
 {
     private static array $db = [
         'BlockBackgroundColor' => 'Varchar(255)',

--- a/src/Extensions/DefaultRecordsExtension.php
+++ b/src/Extensions/DefaultRecordsExtension.php
@@ -9,18 +9,16 @@ use Page;
 use SilverStripe\Assets\Image;
 use SilverStripe\CMS\Controllers\RootURLController;
 use SilverStripe\Control\Director;
-use SilverStripe\Core\Manifest\ModuleResourceLoader;
+use SilverStripe\Core\Extension;
 use SilverStripe\LinkField\Models\ExternalLink;
-use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\StartupThemeComponents\Elemental\Block\ImageTextBlock;
 use SilverStripe\StartupThemeComponents\PageTypes\BlocksPage;
-use SilverStripe\View\ThemeResourceLoader;
 
-class DefaultRecordsExtension extends DataExtension
+class DefaultRecordsExtension extends Extension
 {
     /**
      * The Startup theme ships with some specific content, so we'll create this on creation of the SiteConfig.
@@ -29,8 +27,6 @@ class DefaultRecordsExtension extends DataExtension
      */
     public function requireDefaultRecords(): void
     {
-        parent::requireDefaultRecords();
-
         // On initial dev-build, the default SiteConfig is created.
         // So provided SiteConfig doesn't exist, we know this is the first dev/build on a fresh DB,
         // and we want to create default pages, menus and blocks.

--- a/src/Extensions/ElementContentExtension.php
+++ b/src/Extensions/ElementContentExtension.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\StartupTheme;
 
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
 
-class ElementContentExtension extends DataExtension
+class ElementContentExtension extends Extension
 {
     private static array $db = [
         'BlockNarrowContentWidth' => 'Varchar(255)',

--- a/src/Extensions/HeaderButtonExtension.php
+++ b/src/Extensions/HeaderButtonExtension.php
@@ -2,12 +2,12 @@
 
 namespace SilverStripe\StartupTheme;
 
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\LinkField\Form\LinkField;
 use SilverStripe\LinkField\Models\Link;
-use SilverStripe\ORM\DataExtension;
 
-class HeaderButtonExtension extends DataExtension {
+class HeaderButtonExtension extends Extension {
 
     private static array $has_one = [
         'HeaderButton' => Link::class

--- a/src/Extensions/PageExtension.php
+++ b/src/Extensions/PageExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SilverStripe\StartupTheme;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\CheckboxSetField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextareaField;
+
+class PageExtension extends Extension
+{
+
+    private static array $db = [
+        'Intro' => 'Text',
+        'ShowSiblingMenu' => 'Boolean',
+    ];
+
+    private static array $defaults = [
+        'ShowSiblingMenu' => true,
+    ];
+
+    public function updateCMSFields(FieldList $fields): void
+    {
+        $fields->insertBefore(
+            'Content',
+            TextareaField::create(
+                'Intro',
+                'Summary Intro',
+            )->setDescription('Summary introduction above the content.'),
+        );
+
+        $fields->insertAfter(
+            'Content',
+            CheckboxSetField::create(
+                'ShowSiblingMenu',
+                'Show Sibling Menu',
+                [
+                    '1' => 'If this is a sub-page with siblings, display a sibling menu',
+                ]
+            )
+        );
+    }
+
+
+}

--- a/src/Extensions/PageExtension.php
+++ b/src/Extensions/PageExtension.php
@@ -29,7 +29,7 @@ class PageExtension extends Extension
             )->setDescription('Summary introduction above the content.'),
         );
 
-        $fields->insertAfter(
+        $fields->insertBefore(
             'Content',
             CheckboxSetField::create(
                 'ShowSiblingMenu',
@@ -40,6 +40,5 @@ class PageExtension extends Extension
             )
         );
     }
-
 
 }

--- a/src/Extensions/SiteConfigExtension.php
+++ b/src/Extensions/SiteConfigExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\StartupTheme;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextField;
+
+class SiteConfigExtension extends Extension
+{
+
+    private static array $db = [
+        'FooterCopyright' => 'Text'
+    ];
+
+    public function updateCMSFields(FieldList $fields): void
+    {
+        $fields->addFieldsToTab(
+            'Root.Main',
+            [
+                TextField::create(
+                    'FooterCopyright',
+                    'Footer Copyright'
+                )->setDescription('Customise the copyright text in the footer (leave blank to default to site title)'),
+            ]
+        );
+    }
+
+}

--- a/src/PageTypes/BlocksPage.php
+++ b/src/PageTypes/BlocksPage.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\StartupThemeComponents\PageTypes;
 
 use Page;
-use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\TextareaField;
 
 class BlocksPage extends Page
@@ -26,12 +26,17 @@ class BlocksPage extends Page
     {
         $fields = parent::getCMSFields();
 
+        $fields->removeByName('ShowSiblingMenu');
+
         $fields->insertAfter(
             'MenuTitle',
-            CheckboxField::create(
+            CheckboxSetField::create(
                 'ShowHero',
                 'Show Hero',
-            )->setDescription('Show hero area containing breadcrumbs and page name.'),
+                [
+                    '1' => 'Show hero area containing breadcrumbs and page name',
+                ]
+            )
         );
 
         $fields->insertAfter(
@@ -39,7 +44,7 @@ class BlocksPage extends Page
             TextareaField::create(
                 'Intro',
                 'Summary Intro',
-            )->setDescription('Summary introduction in the hero area.'),
+            )->setDescription('Summary introduction in the hero area. Only visible if Show Hero is ticked.'),
         );
 
         return $fields;

--- a/themes/startup-theme-components/templates/Includes/Footer.ss
+++ b/themes/startup-theme-components/templates/Includes/Footer.ss
@@ -3,7 +3,12 @@
         <nav aria-label="Footer">
             <ul class="footer-menu">
                 <li class="footer-menu__item footer-menu__item--copyright">
-                    &copy; $CurrentDatetime.Format("y") $SiteConfig.Title
+                    &copy; $now.Format("y")
+                    <% if $SiteConfig.FooterCopyright %> 
+                        $SiteConfig.FooterCopyright
+                    <% else %>
+                        $SiteConfig.Title
+                    <% end_if %>
                 </li>
                 <% loop $MenuSet('FooterMenu').MenuItems %>
                     <li class="footer-menu__item">

--- a/themes/startup-theme-components/templates/Layout/Page.ss
+++ b/themes/startup-theme-components/templates/Layout/Page.ss
@@ -1,0 +1,30 @@
+<main class="container container--page">
+    <% if not $isHomePage %>
+        $Breadcrumbs
+    <% end_if %>
+    <div class="page">
+        <div class="page__content">
+            <h1 class="page__title">$Title</h1>
+            <% if $Intro %>
+                <p class="page__intro">$Intro</p>
+            <% end_if %>
+            $Content
+        </div>
+        <% if $ShowSiblingMenu && $Menu($PageLevel).count > 1 && $PageLevel > 1 %>
+            <aside class="page-menu">
+                <a href="$Parent.Link" class="h5 page-menu__heading">$Parent.Title</a>
+                <nav class="page-menu__nav">
+                    <ul class="page-menu__list">
+                    <% loop $Menu($PageLevel) %>
+                        <% if $isCurrent %>
+                            <li class="page-menu__list-item page-menu__list-item--current">$Title</li>
+                        <% else %>
+                            <li class="page-menu__list-item"><a href="$Link">$Title</a></li>
+                        <% end_if %>
+                    <% end_loop %>
+                    </ul>
+                </nav>
+            </aside>
+        <% end_if %>
+    </div>
+</main>


### PR DESCRIPTION
Since the theme cant ship any PHP these features need to be added to the module.

There will be a text field for the intro and a boolean checkbox field to toggle sibling menu.

In site config a text field to customise the copyright text (defaults to site name)



AC’s:

- Add intro field to page (plain text)
- Add a checkbox to hide the sibling menu
- textfield in siteconfig for the copyright text

[Matching PR](https://github.com/silverstripeltd/startup-theme/pull/20)