### PR TITLE
SDEMO-708: Image alt text field

### DIFF
--- a/_config/startup.yml
+++ b/_config/startup.yml
@@ -15,6 +15,14 @@ Heyday\MenuManager\MenuSet:
     - MainMenu
     - FooterMenu
 
+SilverStripe\AssetAdmin\Forms\FileFormFactory:
+  extensions:
+    - SilverStripe\StartupTheme\FileFormFactoryExtension
+
+SilverStripe\Assets\Image:
+  extensions:
+    - SilverStripe\StartupTheme\ImageExtension
+
 SilverStripe\SiteConfig\SiteConfig:
   extensions:
     - SilverStripe\StartupTheme\DefaultRecordsExtension

--- a/src/Extensions/FileFormFactoryExtension.php
+++ b/src/Extensions/FileFormFactoryExtension.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\StartupTheme;
 
+use SilverStripe\AssetAdmin\Forms\AssetFormFactory;
 use SilverStripe\Forms\Tip;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
@@ -12,29 +13,35 @@ class FileFormFactoryExtension extends DataExtension
 {
     public function updateFormFields(FieldList $fields, $controller, $name, $context)
     {
-        $record = $context['Record'];
+        $record = $context['Record'] ?? null;
+        $type = $context['Type'] ?? null;
 
-        if ($record->appCategory() === 'image') {
-            $fields->insertAfter(
-                'Title',
-                $altTextField = TextField::create(
-                    'AltText',
-                    _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltText', 'Alternative text (alt)')
-                )
-            );
-
-            $altTextDescription = _t(
-                'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextTip',
-                'Description for visitors who are unable to view the image (using screenreaders or ' .
-                'image blockers). Recommended for images which provide unique context to the content.'
-            );
-
-            if ($altTextField instanceof TippableFieldInterface) {
-                $altTextField->setTip(new Tip($altTextDescription, Tip::IMPORTANCE_LEVELS['HIGH']));
-            } else {
-                $altTextField->setDescription($altTextDescription);
-            }
+        if (!$record || $record->appCategory() !== 'image') {
+            return;
         }
+
+        $altTextField = TextField::create(
+            'AltText',
+            _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltText', 'Alternative text (alt)')
+        );
+
+        if ($type) {
+            $altTextField = $altTextField->performReadonlyTransformation();
+        }
+
+        $altTextDescription = _t(
+            'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextTip',
+            'Description for visitors who are unable to view the image (using screenreaders or ' .
+            'image blockers). Recommended for images which provide unique context to the content.'
+        );
+
+        if ($altTextField instanceof TippableFieldInterface) {
+            $altTextField->setTip(new Tip($altTextDescription, Tip::IMPORTANCE_LEVELS['HIGH']));
+        } else {
+            $altTextField->setDescription($altTextDescription);
+        }
+
+        $fields->insertAfter('Title', $altTextField);
     }
 
 }

--- a/src/Extensions/FileFormFactoryExtension.php
+++ b/src/Extensions/FileFormFactoryExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SilverStripe\StartupTheme;
+
+use SilverStripe\Forms\Tip;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Forms\TippableFieldInterface;
+
+class FileFormFactoryExtension extends DataExtension
+{
+    public function updateFormFields(FieldList $fields, $controller, $name, $context)
+    {
+        $record = $context['Record'];
+
+        if ($record->appCategory() === 'image') {
+            $fields->insertAfter(
+                'Title',
+                $altTextField = TextField::create(
+                    'AltText',
+                    _t('SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltText', 'Alternative text (alt)')
+                )
+            );
+
+            $altTextDescription = _t(
+                'SilverStripe\\AssetAdmin\\Controller\\AssetAdmin.AltTextTip',
+                'Description for visitors who are unable to view the image (using screenreaders or ' .
+                'image blockers). Recommended for images which provide unique context to the content.'
+            );
+
+            if ($altTextField instanceof TippableFieldInterface) {
+                $altTextField->setTip(new Tip($altTextDescription, Tip::IMPORTANCE_LEVELS['HIGH']));
+            } else {
+                $altTextField->setDescription($altTextDescription);
+            }
+        }
+    }
+
+}

--- a/src/Extensions/ImageExtension.php
+++ b/src/Extensions/ImageExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\StartupTheme;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\CheckboxSetField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextareaField;
+
+class ImageExtension extends Extension
+{
+
+    private static array $db = [
+        'AltText' => 'Varchar(255)',
+    ];
+
+    /**
+     * Update attribute hook
+     *
+     * Change the alt attribute value to `AltText` instead of `Title`
+     * Allows for an empty value to indicate a decorative image
+     */
+    public function updateAttributes(array &$attributes): void
+    {
+        $attributes['alt'] = $this->owner->AltText;
+    }
+
+}

--- a/themes/startup-theme-components/templates/Includes/Header.ss
+++ b/themes/startup-theme-components/templates/Includes/Header.ss
@@ -27,7 +27,7 @@
         <%-- SiteConfig header button link --%>
         <% with $SiteConfig  %>
             <% if $HeaderButton %>
-                <a class="header__button button button--header<% if $HeaderButton.OpenInNew %> button--external<% end_if %>"
+                <a class="button button--secondary-on-dark<% if $HeaderButton.OpenInNew %> button--external<% end_if %> header__button"
                    href="$HeaderButton.URL"
                    <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
                 >

--- a/themes/startup-theme-components/templates/Layout/Page.ss
+++ b/themes/startup-theme-components/templates/Layout/Page.ss
@@ -6,7 +6,7 @@
         <div class="page__content">
             <h1 class="page__title">$Title</h1>
             <% if $Intro %>
-                <p class="page__intro">$Intro</p>
+                <p class="intro page__intro">$Intro</p>
             <% end_if %>
             $Content
         </div>

--- a/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/Elemental/Block/ImageTextBlock.ss
+++ b/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/Elemental/Block/ImageTextBlock.ss
@@ -27,7 +27,7 @@
                 <source media="(min-width: 992px)" srcset="$ImageTextBlockImage.ScaleWidth(885).URL"/>
                 <source media="(min-width: 750px)" srcset="$ImageTextBlockImage.ScaleWidth(675).URL"/>
                 <source media="(min-width: 450px)" srcset="$ImageTextBlockImage.ScaleWidth(1065).URL"/>
-                <img src="$ImageTextBlockImage.ScaleWidth(615).URL" alt="$ImageTextBlockImage.Title" />
+                <img src="$ImageTextBlockImage.ScaleWidth(615).URL" alt="$ImageTextBlockImage.AltText" />
             </picture>
         </div>
     </div>

--- a/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/PageTypes/Layout/BlocksPage.ss
+++ b/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/PageTypes/Layout/BlocksPage.ss
@@ -2,11 +2,13 @@
     <% if $ShowHero %>
         <div class="hero">
             <div class="container">
-                $Breadcrumbs
-                <h1 class="page__title">$Title</h1>
-                <% if $Intro %>
-                    <p class="page__intro">$Intro</p>
-                <% end_if %>
+                <div class="hero__inner">
+                    $Breadcrumbs
+                    <h1 class="hero__title">$Title</h1>
+                    <% if $Intro %>
+                        <p class="intro hero__intro">$Intro</p>
+                    <% end_if %>
+                </div>
             </div>
         </div>
     <% end_if %>


### PR DESCRIPTION
## SDEMO-708: Image alt text field

Currently there is no way to indicate an image is decorative by means of empty alt text, or to provide a different description to the image title.

### Summary of changes
- Add alt text field, so that alternative text can be added via asset admin
- Other amends and improvements

### Other PRs as part of this card:
- https://github.com/silverstripeltd/startup-theme/pull/21
- https://github.com/silverstripeltd/demo-startup-staging/pull/9
