### PR TITLE
Updating to match latest startup-theme changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,11 @@
         "heyday/silverstripe-menumanager": "^4.2",
         "dnadesign/silverstripe-elemental": "^5.2",
         "silverstripe/linkfield": "^4.0"
+    },
+    "extra": {
+        "expose": [
+            "themes/startup-theme-components/css",
+            "themes/startup-theme-components/images"
+        ]
     }
 }

--- a/themes/startup-theme-components/css/block.css
+++ b/themes/startup-theme-components/css/block.css
@@ -1,0 +1,71 @@
+/**
+ * Elemental block styles
+ *
+ * These styles are shared across multiple block types
+ */
+.block {
+    display: grid;
+}
+
+.block__h1, .block__h2 {
+    margin: 0;
+}
+
+.block__h1 {
+    @media (min-width: 750px) {
+        line-height: 1.1;
+    }
+}
+
+.block__h2 {
+    font-size: 3.4rem;
+
+    @media (min-width: 750px) {
+        font-size: 4rem;
+    }
+}
+
+/**
+ * Content block styles
+ */
+.content-block {
+    gap: 1.8rem;
+
+    @media (min-width: 750px) {
+        gap: 2rem;
+    }
+}
+
+/**
+ * Image and text block styles
+ */
+.image-and-text-block {
+    display: grid;
+    gap: 4rem;
+
+    @media (min-width: 750px) {
+        display: flex;
+    }
+
+    @media (min-width: 1170px) {
+        gap: 10rem;
+    }
+}
+
+.image-and-text-block--left {
+    @media (min-width: 750px) {
+        flex-direction: row-reverse;
+    }
+}
+
+.image-and-text-block__right-column {
+    align-self: center;
+    display: grid;
+    flex-shrink: 0;
+    gap: 2.5rem;
+
+    @media (min-width: 750px) {
+        width: clamp(34rem, 48%, 50rem);
+        gap: 3rem;
+    }
+}

--- a/themes/startup-theme-components/css/hero.css
+++ b/themes/startup-theme-components/css/hero.css
@@ -1,0 +1,18 @@
+.hero {
+    background-color: var(--color-pale-grey);
+    padding-bottom: 4rem;
+    padding-top: 5rem;
+
+    @media (min-width: 992px) {
+        padding-bottom: 5rem;
+        padding-top: 7rem;
+    }
+}
+
+.hero__inner {
+    max-width: 77rem;
+}
+
+.hero__intro {
+    margin-top: 2rem;
+}

--- a/themes/startup-theme-components/css/menus.css
+++ b/themes/startup-theme-components/css/menus.css
@@ -1,0 +1,28 @@
+/* add chevron if item has child menu */
+.menu__item--has-submenu > .menu__link::after {
+    content: url('../images/chevron--down--white.svg');
+    display: inline-block;
+    margin-left: 0.5rem;
+    transition: var(--transition-default);
+}
+
+/* chevron hover animation, also applied on submenu hover */
+.menu__item--has-submenu:hover .menu__link::after,
+.menu__item--has-submenu:focus-within .menu__link::after,
+.menu__item--has-submenu:has(.submenu:hover) .menu__link::after {
+    transform: rotate(-180deg);
+}
+
+/* submenu */
+.submenu {
+    opacity: 0;
+    visibility: hidden;
+}
+
+/* Mobile submenu */
+.mobile-submenu-container {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: var(--transition-default);
+    visibility: hidden;
+}

--- a/themes/startup-theme-components/css/section.css
+++ b/themes/startup-theme-components/css/section.css
@@ -1,0 +1,40 @@
+/* Section styles */
+.section {
+    padding: 6rem 0;
+
+    @media (min-width: 992px) {
+        padding: 10rem 0;
+    }
+}
+
+.section--color-white + .section--color-white {
+    padding-top: 0;
+}
+
+.section--color-dark {
+    color: var(--color-white);
+}
+
+.section--color-black {
+    background-color: var(--color-black);
+}
+
+.section--color-charcoal {
+    background-color: var(--color-charcoal);
+}
+
+.section--color-grey {
+    background-color: var(--color-grey);
+}
+
+.section--color-line-grey {
+    background-color: var(--color-line-grey);
+}
+
+.section--color-pale-grey {
+    background-color: var(--color-pale-grey);
+}
+
+.section--color-bright-blue {
+    background-color: var(--color-bright-blue);
+}

--- a/themes/startup-theme-components/css/startup-components.css
+++ b/themes/startup-theme-components/css/startup-components.css
@@ -1,0 +1,3 @@
+@import 'block.css';
+@import 'hero.css';
+@import 'section.css';

--- a/themes/startup-theme-components/images/chevron--down--white.svg
+++ b/themes/startup-theme-components/images/chevron--down--white.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 1.88973L1.29663 0.5L5.50183 5.08612L9.70337 0.5L11 1.88973L5.50183 7.86607L0 1.88973Z" fill="#bdbdbd"/>
+</svg>

--- a/themes/startup-theme-components/templates/Includes/Header.ss
+++ b/themes/startup-theme-components/templates/Includes/Header.ss
@@ -1,91 +1,102 @@
+<% require themedCSS('startup-components') %>
 <header class="header">
     <a href="#main" class="button button--on-dark button--skip">Skip to main content</a>
 
-    <div class="container container--header">
-        <a href="$baseURL" class="logo" aria-label="Home">
-            <img src="$resourceURL('themes/startup-theme/images/logo--white.svg')" width="117" height="22" alt="">
-        </a>
+<div class="container container--header">
+    <a href="$baseURL" class="logo" aria-label="Home">
+        <img src="$themedResourceURL('images/logo--white.svg')" width="117" height="22" alt="">
+    </a>
 
-        <%-- Desktop menu --%>
-        <nav class="nav nav--desktop" aria-label="Main">
-            <ul class="menu">
-                <% loop $MenuSet('MainMenu').MenuItems %>
-                    <li class="menu__item<% if $Children %> menu__item--has-submenu<% end_if %>">
-                        <a href="$Link" class="menu__link menu__link--{$LinkingMode}" <% if $IsNewWindow %>target="_blank" rel="noopener noreferrer"<% end_if %>>$MenuTitle</a>
-                        <% if $Children %>
-                            <ul class="submenu">
+    <%-- Desktop menu --%>
+<nav class="nav nav--desktop" aria-label="Main">
+<ul class="menu accordion">
+    <% loop $MenuSet('MainMenu').MenuItems %>
+    <li class="menu__item<% if $Children %> menu__item--has-submenu accordion__item<% end_if %>" data-close-on-defocus>
+    <div class="menu__item-container">
+        <a id="{$URLSegment}-submenu-link" href="$Link" class="menu__link menu__link--{$LinkingMode}" <% if $IsNewWindow %>target="_blank" rel="noopener noreferrer"<% end_if %>>$MenuTitle</a>
+        <% if $Children %>
+            <button class="submenu-chevron accordion__toggle" type="button" aria-label="Open $MenuTitle submenu" aria-expanded="false" aria-controls="{$URLSegment}-submenu" data-accordion-flip>
+                <svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <path d="M0 1.88973L1.29663 0.5L5.50183 5.08612L9.70337 0.5L11 1.88973L5.50183 7.86607L0 1.88973Z" fill="currentcolor" />
+                </svg>
+            </button>
+        </div><%-- close .menu__item-container --%>
+            <div id="{$URLSegment}-submenu" class="submenu-container accordion__container" aria-labelledby="{$URLSegment}-submenu-link">
+                <ul class="submenu">
+                    <% loop $Children %>
+                        <li class="submenu__item">
+                            <a href="$Link" class="submenu__link submenu__link--{$LinkingMode}">$MenuTitle</a>
+                        </li>
+                    <% end_loop %>
+                </ul>
+            </div>
+        <% else %>
+        </div><%-- close .menu__item-container --%>
+        <% end_if %>
+        </li>
+    <% end_loop %>
+    </ul>
+
+    </nav>
+    <%-- SiteConfig header button link --%>
+    <% with $SiteConfig  %>
+        <% if $HeaderButton %>
+            <a class="button button--secondary-on-dark<% if $HeaderButton.OpenInNew %> button--external<% end_if %> header__button"
+               href="$HeaderButton.URL"
+                <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
+            >
+                $HeaderButton.Title
+            </a>
+        <% end_if %>
+    <% end_with %>
+
+    <%-- Mobile menu controls --%>
+    <button class="hamburger" type="button" aria-label="Toggle menu" data-toggle-mobile-menu>
+        <span class="hamburger__lines"></span>
+    </button>
+
+    <%-- Mobile menu background - can be clicked to close menu --%>
+    <div class="modal__background" data-toggle-mobile-menu></div>
+
+    <%-- Mobile menu --%>
+    <nav class="nav nav--mobile" aria-label="Main">
+        <a href="$BaseHref" class="logo logo--mobile">
+            <img class="logo__image" src="$themedResourceURL('images/logo--black.svg')" width="117" height="22" alt="{$SiteConfig.Title}">
+        </a>
+        <ul class="mobile-menu accordion">
+            <% loop $MenuSet('MainMenu').MenuItems %>
+                <li class="mobile-menu__item<% if $Children %> mobile-menu__item--has-submenu accordion__item<% end_if %>">
+                    <a href="$Link" id="{$URLSegment}-mobile-submenu-link" class="mobile-menu__link" <% if $IsNewWindow %>target="_blank" rel="noopener noreferrer"<% end_if %>>$MenuTitle</a>
+                    <% if $Children %>
+                        <button class="mobile-submenu-chevron accordion__toggle" type="button" aria-label="Open $MenuTitle submenu" aria-expanded="false" aria-controls="{$URLSegment}-mobile-submenu" data-accordion-flip>
+                            <svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                <path d="M0 1.88973L1.29663 0.5L5.50183 5.08612L9.70337 0.5L11 1.88973L5.50183 7.86607L0 1.88973Z" fill="currentcolor"/>
+                            </svg>
+                        </button>
+                        <div id="{$URLSegment}-mobile-submenu" class="mobile-submenu-container accordion__container" aria-labelledby="{$URLSegment}-mobile-submenu-link">
+                            <ul class="mobile-submenu">
                                 <% loop $Children %>
-                                    <li class="submenu__item">
-                                        <a href="$Link" class="submenu__link submenu__link--{$LinkingMode}">$MenuTitle</a>
+                                    <li class="mobile-submenu__item">
+                                        <a href="$Link" title="$Title" class="mobile-submenu__link">$MenuTitle</a>
                                     </li>
                                 <% end_loop %>
                             </ul>
-                        <% end_if %>
-                    </li>
-                <% end_loop %>
-            </ul>
-        </nav>
-
-        <%-- SiteConfig header button link --%>
+                        </div>
+                    <% end_if %>
+                </li>
+            <% end_loop %>
+        </ul>
+        <%-- SiteConfig mobile nav header button link  --%>
         <% with $SiteConfig  %>
             <% if $HeaderButton %>
-                <a class="button button--secondary-on-dark<% if $HeaderButton.OpenInNew %> button--external<% end_if %> header__button"
+                <a class="mobile-menu__button button<% if $HeaderButton.OpenInNew %> button--external<% end_if %>"
                    href="$HeaderButton.URL"
-                   <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
+                    <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
                 >
                     $HeaderButton.Title
                 </a>
             <% end_if %>
         <% end_with %>
-
-        <%-- Mobile menu controls --%>
-        <button class="hamburger" type="button" aria-label="Toggle menu" data-toggle-mobile-menu>
-            <span class="hamburger__lines"></span>
-        </button>
-
-        <%-- Mobile menu background - can be clicked to close menu --%>
-        <div class="modal__background" data-toggle-mobile-menu></div>
-
-        <%-- Mobile menu --%>
-        <nav class="nav nav--mobile" aria-label="Main">
-            <a href="$BaseHref" class="logo logo--mobile" aria-label="Home">
-                <img class="logo__image" src="$resourceURL('themes/startup-theme/images/logo--black.svg')" width="117" height="22" alt="">
-            </a>
-            <ul class="mobile-menu" data-accordion>
-                <% loop $MenuSet('MainMenu').MenuItems %>
-                    <li class="mobile-menu__item<% if $Children %> mobile-menu__item--has-submenu<% end_if %>" <% if $Children %>data-accordion-item<% end_if %>>
-                        <a href="$Link" id="{$URLSegment}-submenu-link" class="mobile-menu__link" <% if $IsNewWindow %>target="_blank" rel="noopener noreferrer"<% end_if %>
-                        >$MenuTitle</a>
-                        <% if $Children %>
-                            <button class="submenu-chevron" type="button" aria-label="Open $MenuTitle submenu" aria-expanded="false" aria-controls="{$URLSegment}-submenu" data-accordion-link>
-                                <svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                    <path d="M0 1.88973L1.29663 0.5L5.50183 5.08612L9.70337 0.5L11 1.88973L5.50183 7.86607L0 1.88973Z" fill="#2D2828B3"/>
-                                </svg>
-                            </button>
-                            <div id="{$URLSegment}-submenu" class="mobile-submenu-container" aria-labelledby="{$URLSegment}-submenu-link">
-                                <ul class="mobile-submenu">
-                                    <% loop $Children %>
-                                        <li class="mobile-submenu__item">
-                                            <a href="$Link" title="$Title" class="mobile-submenu__link">$MenuTitle</a>
-                                        </li>
-                                    <% end_loop %>
-                                </ul>
-                            </div>
-                        <% end_if %>
-                    </li>
-                <% end_loop %>
-            </ul>
-            <%-- SiteConfig mobile nav header button link  --%>
-            <% with $SiteConfig  %>
-                <% if $HeaderButton %>
-                    <a class="mobile-menu__button button<% if $HeaderButton.OpenInNew %> button--external<% end_if %>"
-                       href="$HeaderButton.URL"
-                       <% if $HeaderButton.OpenInNew %>target="_blank" rel="noopener noreferrer"<% end_if %>
-                    >
-                        $HeaderButton.Title
-                    </a>
-                <% end_if %>
-            <% end_with %>
-        </nav>
+    </nav>
     </div>
 </header>

--- a/themes/startup-theme-components/templates/Layout/Page.ss
+++ b/themes/startup-theme-components/templates/Layout/Page.ss
@@ -3,7 +3,7 @@
         $Breadcrumbs
     <% end_if %>
     <div class="page">
-        <div class="page__content">
+        <div class="page__content <% if $Menu($PageLevel).count > 1 && $PageLevel > 1 %>page__content--with-sidebar<% end_if %>">
             <h1 class="page__title">$Title</h1>
             <% if $Intro %>
                 <p class="intro page__intro">$Intro</p>
@@ -11,22 +11,7 @@
             $Content
         </div>
         <% if $ShowSiblingMenu && $Menu($PageLevel).count > 1 && $PageLevel > 1 %>
-            <aside class="page-menu">
-                <nav class="page-menu__nav" aria-labelledby="page-menu-heading">
-                    <h2 id="page-menu-heading" class="h5 page-menu__heading">
-                        <a href="$Parent.Link" class="page-menu__heading-link">$Parent.Title</a>
-                    </h2>
-                    <ul class="page-menu__list">
-                    <% loop $Menu($PageLevel) %>
-                        <% if $isCurrent %>
-                            <li class="page-menu__list-item page-menu__list-item--current">$Title</li>
-                        <% else %>
-                            <li class="page-menu__list-item"><a href="$Link">$Title</a></li>
-                        <% end_if %>
-                    <% end_loop %>
-                    </ul>
-                </nav>
-            </aside>
+            <% include Sidebar %>
         <% end_if %>
     </div>
 </main>


### PR DESCRIPTION
When `startup-theme` was handed to product, understandably CSS etc that referred to the blocks in this module were removed. This PR reinstates these and updates the templating to use the updated DOM and classes from `startup-theme`.

Brooke to test this, update the staging repo by running `composer install` locally in that project which will get the latest startup theme. Then checkout this branch of the components module. You'll be checking to make sure everything looks good - I used the UAT database for this 