### PR TITLE
SDEMO-782 code review adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ vendor/bin/sake db:build
 ```
 
 As part of the build process, this module will move its theme files into your project's root `themes` folder.
-It will also augment the default `startup-theme` CSS folder with dome additional files from this module.
+It will also augment the default `startup-theme` CSS folder with some additional files from this module.
 In your project's `app/_config/theme.yml` file, add the `startup-theme-components` theme as the default theme.
 Your config should look something like this:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -5,25 +5,34 @@ This module extends the Startup theme with some commonly used modules, and some 
 ## Installation
 This module should be installed as part of a clean Silverstripe project if you'd like all the default content to be created.
 
-This guide assumes you have [Composer](https://getcomposer.org/) installed.
+This guide assumes you have [Composer](https://getcomposer.org/) installed, as well as knowlege of running a webserver with PHP and a database.
 
 In the CLI, navigate to the folder where you want to create your Silverstripe project.
 
 Create a new Silverstripe project via composer:
 ```bash
-composer create-project silverstripe/installer my-project
+composer create-project silverstripe/installer {my-project}
 ```
 
 Navigate to your project folder:
 ```bash
-cd my-project
+cd {my-project}
 ```
+
+Point your webserver root to the `public` folder inside your project folder.
 
 Then require the `startup-theme-components` module:
 ```bash
 composer require silverstripeltd/startup-theme-components
 ```
 
+As with most Silverstripe modules, you'll need to then build the database fields.
+```bash
+vendor/bin/sake db:build
+```
+
+As part of the build process, this module will move its theme files into your project's root `themes` folder.
+It will also augment the default `startup-theme` CSS folder with dome additional files from this module.
 In your project's `app/_config/theme.yml` file, add the `startup-theme-components` theme as the default theme.
 Your config should look something like this:
 ```yaml
@@ -32,14 +41,15 @@ Name: mytheme
 ---
 SilverStripe\View\SSViewer:
   themes:
-    - 'silverstripeltd/startup-theme-components:startup-theme-components'
+    - 'startup-theme-components'
     - 'startup-theme'
     - '$public'
     - '$default'
 ```
 
-You can now set up your .env file as required, and run a dev/build to create the database tables and default content,
-see the [quick start guide](https://docs.silverstripe.org/en/6/getting_started/#quickstart-installation)
+You can now modify and extend the theme as you like. See here for more information on [customising themes](https://docs.silverstripe.org/en/6/developer_guides/templates/themes/).
+
+Now set up your .env file as required, see the [quick start guide](https://docs.silverstripe.org/en/6/getting_started/#quickstart-installation)
 
 ## Included Modules
 

--- a/src/Extensions/ElementContentExtension.php
+++ b/src/Extensions/ElementContentExtension.php
@@ -9,7 +9,7 @@ use SilverStripe\Forms\FieldList;
 class ElementContentExtension extends Extension
 {
     private static array $db = [
-        'BlockNarrowContentWidth' => 'Varchar(255)',
+        'BlockNarrowContentWidth' => 'Boolean',
     ];
 
     /**

--- a/src/Extensions/PageExtension.php
+++ b/src/Extensions/PageExtension.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\StartupTheme;
 
 use SilverStripe\Core\Extension;
-use SilverStripe\Forms\CheckboxSetField;
+use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextareaField;
 
@@ -31,13 +31,10 @@ class PageExtension extends Extension
 
         $fields->insertBefore(
             'Content',
-            CheckboxSetField::create(
+            CheckboxField::create(
                 'ShowSiblingMenu',
-                'Show Sibling Menu',
-                [
-                    '1' => 'If this is a sub-page with siblings, display a sibling menu',
-                ]
-            )
+                'Show Sibling Menu'
+            )->setDescription('If this is a sub-page with siblings, display a sibling menu')
         );
     }
 

--- a/themes/startup-theme-components/templates/Layout/Page.ss
+++ b/themes/startup-theme-components/templates/Layout/Page.ss
@@ -17,3 +17,5 @@
         <% end_if %>
     </div>
 </main>
+
+$ElementalArea

--- a/themes/startup-theme-components/templates/Layout/Page.ss
+++ b/themes/startup-theme-components/templates/Layout/Page.ss
@@ -1,21 +1,22 @@
-<main id="main" class="container container--page" tabindex="-1">
-    <% if not $isHomePage %>
-        $Breadcrumbs
-    <% end_if %>
-    <div class="page">
-        <div class="page__content">
-            <h1 class="page__title">$Title</h1>
-            <% if $Intro %>
-                <p class="intro page__intro">$Intro</p>
-            <% end_if %>
-            $Content
-        </div>
-        <% if $PageLevel == 1 && $Children && $ShowSiblingMenu %>
-            <% include LevelOneSidebar %>
-        <% else_if $PageLevel > 1 && $Menu($PageLevel).count > 1 && $ShowSiblingMenu %>
-            <% include Sidebar %>
+<main id="main" tabindex="-1">
+    <div class="container container--page">
+        <% if not $isHomePage %>
+            $Breadcrumbs
         <% end_if %>
+        <div class="page">
+            <div class="page__content">
+                <h1 class="page__title">$Title</h1>
+                <% if $Intro %>
+                    <p class="intro page__intro">$Intro</p>
+                <% end_if %>
+                $Content
+            </div>
+            <% if $PageLevel == 1 && $Children && $ShowSiblingMenu %>
+                <% include LevelOneSidebar %>
+            <% else_if $PageLevel > 1 && $Menu($PageLevel).count > 1 && $ShowSiblingMenu %>
+                <% include Sidebar %>
+            <% end_if %>
+        </div>
     </div>
+    $ElementalArea
 </main>
-
-$ElementalArea

--- a/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/Elemental/Block/ImageTextBlock.ss
+++ b/themes/startup-theme-components/templates/SilverStripe/StartupThemeComponents/Elemental/Block/ImageTextBlock.ss
@@ -27,7 +27,7 @@
                 <source media="(min-width: 992px)" srcset="$ImageTextBlockImage.ScaleWidth(885).URL"/>
                 <source media="(min-width: 750px)" srcset="$ImageTextBlockImage.ScaleWidth(675).URL"/>
                 <source media="(min-width: 450px)" srcset="$ImageTextBlockImage.ScaleWidth(1065).URL"/>
-                <img src="$ImageTextBlockImage.ScaleWidth(615).URL" alt="$ImageTextBlockImage.AltText" />
+                $ImageTextBlockImage.ScaleWidth(615)
             </picture>
         </div>
     </div>


### PR DESCRIPTION
Thanks Ishan for your feedback on the module. Here are the changes and considerations I've made from your points:

- Corrected field type for ElementContentExtension
- In regards to the alt text, I had a look into this and it is intentionally left blank unless the content author specifically needs alt text for an image which presents some information and is not purely decorative. In this case of the placeholder content, the images are decorative and should not have alt text. See the phpdoc comment on the function on ImageExtension, and this article here for more context: https://www.boia.org/blog/when-should-i-use-empty-or-null-alt-text-attributes. I did fix the template for the ImageTextBlock to call the image template function directly so that we get correct markup and the updateAttributes hook is called upon correctly.
- Updated to correct checkbox field on the page extension - good spotting.
- I had a good think about the partial caching suggestion and I don't think it is appropriate for this project for a few reasons. Firstly the cachekey generation will be complicated as there are several database dependencies for each of these templates (siteconfig and menumanager) and I am not sure how much more optmised we can make the cachekey, seeing as we are going to need to make multiple DB calls to check the key anyway. There is also the possibility of introducing new bugs by adding these and we are running low on time for this project. Also, since this is meant to be code that someone can just jump in and adjust quickly, caching might be confusing for a new dev who is making changes to a template, but the template is cached and the changes are not reflected as they havent modified the database. 
- I investigated having composer copy the theme files and this wont work for a vendormodule unfortunately, the dev will have to modify top level composer.json. So to work around this, I added some functions to the DefaultRecordsExtension. On dev/build the module will see if the themes folder in the root has the startup-theme-components folder, and copies the templates and images folders. The css needed to go into the startup-theme css folder as this is already exposed - I couldn't find another way to handle this automatically. I think its ok to have all the css in one place anyway.
- Finally I updated the docs to be a bit clearer as to what is going on.